### PR TITLE
fix: 🐛 Fix multiple select bug

### DIFF
--- a/src/Form.spec.js
+++ b/src/Form.spec.js
@@ -1,55 +1,158 @@
-import '@testing-library/jest-dom/extend-expect'
-import { getByPlaceholderText, getByTestId, waitFor } from '@testing-library/dom'
-import userEvent from '@testing-library/user-event'
-import { render } from '@testing-library/svelte'
-import TestWrapper from './TestWrapper.svelte'
+import "@testing-library/jest-dom/extend-expect";
+import {
+  getByPlaceholderText,
+  getByTestId,
+  waitFor,
+} from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
+import { render } from "@testing-library/svelte";
+import TestWrapper from "./TestWrapper.svelte";
 
 function renderForm(props) {
-  const { container } = render(TestWrapper, props);
-  return container.firstChild;
+  const container = render(TestWrapper, props);
+  return container.container.firstChild;
 }
 
-describe('has correct values', () => {
-  test('default values', async () => {
-    const container = renderForm({ html: `<input name="name" placeholder="Enter name" value="From Test" />` });
-    const pre = getByTestId(container, 'values')
-    expect(pre).toHaveTextContent("From Test")
+describe("has correct values", () => {
+  test("default values", async () => {
+    const container = renderForm({
+      html: `<input name="name" placeholder="Enter name" value="From Test" />`,
+    });
+    const pre = getByTestId(container, "values");
+    expect(pre).toHaveTextContent("From Test");
   });
-  test('one input', async () => {
-    const container = renderForm({ html: `<input name="name" placeholder="Enter name" />` });
-    const input = getByPlaceholderText(container, 'Enter name')
-    userEvent.type(input, "Kevin")
-    const pre = getByTestId(container, 'values')
+  test("one input", async () => {
+    const container = renderForm({
+      html: `<input name="name" placeholder="Enter name" />`,
+    });
+    const input = getByPlaceholderText(container, "Enter name");
+    userEvent.type(input, "Kevin");
+    const pre = getByTestId(container, "values");
     await waitFor(() => {
-      expect(pre).toHaveTextContent("Kevin")
-    })
+      expect(pre).toHaveTextContent("Kevin");
+    });
   });
-  test('checkbox inputs', async () => {
+  test("checkbox inputs", async () => {
     const container = renderForm({
       html: `
         <input type="checkbox" name="movies" value="Space Jam" data-testid="m1" />
         <input type="checkbox" name="movies" value="Home Alone" data-testid="m2" />
-      `
+      `,
     });
-    const input = getByTestId(container, 'm2')
-    userEvent.click(input)
-    const pre = getByTestId(container, 'values')
+    const input = getByTestId(container, "m2");
+    userEvent.click(input);
+    const pre = getByTestId(container, "values");
     await waitFor(() => {
-      expect(pre).toHaveTextContent('{"movies":["Home Alone"]}')
-    })
+      expect(pre).toHaveTextContent('{"movies":["Home Alone"]}');
+    });
   });
-  test('radio button inputs', async () => {
+  test("radio button inputs", async () => {
     const container = renderForm({
       html: `
         <input type="radio" name="gender" value="M" data-testid="g1"/>
         <input type="radio" name="gender" value="F" data-testid="g2"/>
-      `
+      `,
     });
-    const input = getByTestId(container, 'g2')
-    userEvent.click(input)
-    const pre = getByTestId(container, 'values')
+    const input = getByTestId(container, "g2");
+    userEvent.click(input);
+    const pre = getByTestId(container, "values");
     await waitFor(() => {
-      expect(pre).toHaveTextContent('{"gender":"F"}')
-    })
+      expect(pre).toHaveTextContent('{"gender":"F"}');
+    });
+  });
+  test("multi-select input", async () => {
+    const container = renderForm({
+      html: `
+        <input type="checkbox" name="movies" value="Space Jam" data-testid="m1" />
+        <select name="pets" id="pet-select" multiple data-testid="p1">
+          <option value="dog" data-testid="o1">Dog</option>
+          <option value="cat" data-testid="o2">Cat</option>
+          <option value="hamster" data-testid="o3">Hamster</option>
+          <option value="parrot" data-testid="o4">Parrot</option>
+          <option value="spider" data-testid="o5">Spider</option>
+          <option value="goldfish" data-testid="o6">Goldfish</option>
+        </select>
+      `,
+    });
+    const select = getByTestId(container, "p1");
+    userEvent.selectOptions(select, ["dog", "hamster"]);
+    // TODO: Fix this
+    // userEvent.selectOptions doesn't trigger the update
+    // A checkbox was included just to trigger the update with the click below.
+    userEvent.click(getByTestId(container, "m1"));
+    const pre = getByTestId(container, "values");
+    await waitFor(() => {
+      expect(pre).toHaveTextContent(
+        '{"movies":["Space Jam"],"pets":["dog","hamster"]}'
+      );
+    });
+  });
+});
+
+describe("handles reactivity", () => {
+  test("one input", async () => {
+    const container = renderForm({
+      html: `<input name="name" placeholder="Enter name" data-testid="t1"/>`,
+      input: { name: "Rodrigo" },
+    });
+    userEvent.click(getByTestId(container, "b1"));
+
+    const pre = getByTestId(container, "t1");
+    await waitFor(() => {
+      expect(pre.value).toEqual("Rodrigo");
+    });
+  });
+  test("checkbox inputs", async () => {
+    const container = renderForm({
+      html: `
+        <input type="checkbox" name="movies" value="Space Jam" data-testid="m1" />
+        <input type="checkbox" name="movies" value="Home Alone" data-testid="m2" />
+      `,
+      input: { movies: ["Home Alone"] },
+    });
+    userEvent.click(getByTestId(container, "b1"));
+    await waitFor(() => {
+      expect(getByTestId(container, "m1").checked).toBe(false);
+      expect(getByTestId(container, "m2").checked).toBe(true);
+    });
+  });
+  test("radio button", async () => {
+    const container = renderForm({
+      html: `
+        <input type="radio" name="gender" value="M" data-testid="g1"/>
+        <input type="radio" name="gender" value="F" data-testid="g2"/>
+      `,
+      input: { gender: "M" },
+    });
+    userEvent.click(getByTestId(container, "b1"));
+    await waitFor(() => {
+      expect(getByTestId(container, "g1").checked).toBe(true);
+      expect(getByTestId(container, "g2").checked).toBe(false);
+    });
+  });
+  test("multi-select input", async () => {
+    const container = renderForm({
+      html: `
+        <input type="checkbox" name="movies" value="Space Jam" data-testid="m1" />
+        <select name="pets" id="pet-select" multiple data-testid="p1">
+          <option value="dog" data-testid="o1">Dog</option>
+          <option value="cat" data-testid="o2">Cat</option>
+          <option value="hamster" data-testid="o3">Hamster</option>
+          <option value="parrot" data-testid="o4">Parrot</option>
+          <option value="spider" data-testid="o5">Spider</option>
+          <option value="goldfish" data-testid="o6">Goldfish</option>
+        </select>
+      `,
+      input: { pets: ["dog", "hamster"] },
+    });
+    userEvent.click(getByTestId(container, "b1"));
+    await waitFor(() => {
+      expect(getByTestId(container, "o1").selected).toBe(true);
+      expect(getByTestId(container, "o2").selected).toBe(false);
+      expect(getByTestId(container, "o3").selected).toBe(true);
+      expect(getByTestId(container, "o4").selected).toBe(false);
+      expect(getByTestId(container, "o5").selected).toBe(false);
+      expect(getByTestId(container, "o6").selected).toBe(false);
+    });
   });
 });

--- a/src/TestWrapper.svelte
+++ b/src/TestWrapper.svelte
@@ -1,8 +1,13 @@
 <script>
-  import Form from "./Form.svelte";
-
+  import Form from "../src/Form.svelte";
   export let html;
+  export let input = {};
+
   let values;
+
+  function handleClick() {
+    values = { ...input };
+  }
 </script>
 
 <Form bind:values>
@@ -10,3 +15,5 @@
 </Form>
 
 <pre data-testid="values">{JSON.stringify(values)}</pre>
+
+<button on:click={handleClick} data-testid="b1">Click Me</button>

--- a/src/utils/serialize.js
+++ b/src/utils/serialize.js
@@ -1,67 +1,66 @@
 export function serialize(form) {
-  let i = 0, j, key, val, tmp, out = {};
-  const rgx1 = /(radio|checkbox)/i;
-  const rgx2 = /(file|reset|submit|button)/i;
+  const response = {};
 
-  while (tmp = form.elements[i++]) {
-    // Ignore unnamed, disabled, or (...rgx2) inputs
-
-    if (!tmp.name || tmp.disabled || rgx2.test(tmp.type)) continue;
-
-    key = tmp.name;
-
-    // Grab all values from multi-select
-    if (tmp.type === 'select-multiple') {
-      out[key] = [];
-      for (j = 0; j < tmp.options.length; j++) {
-        if (tmp.options[j].selected) {
-          out[key].push(tmp.options[j].value);
+  [...form.elements].forEach(function elements(input, _index) {
+    // I know this "switch (true)" isn't beautiful, but it works!!!
+    switch (true) {
+      case !input.name:
+      case input.disabled:
+      case /(file|reset|submit|button)/i.test(input.type):
+        break;
+      case /(select-multiple)/i.test(input.type):
+        response[input.name] = [];
+        [...input.options].forEach(function options(option, _selectIndex) {
+          if (option.selected) {
+            response[input.name].push(option.value);
+          }
+        });
+        break;
+      case /(radio)/i.test(input.type):
+        if (input.checked) {
+          response[input.name] = input.value;
         }
-      }
-    } else if (rgx1.test(tmp.type)) {
-      if (tmp.checked) {
-        j = out[key];
-        val = tmp.value === 'on' || tmp.value;
-        out[key] = (j == null && j !== 0)
-            ? ((tmp.type === 'radio') ? val : [val])
-            : [].concat(j, val);
-      }
-    } else if (tmp.value || tmp.value === 0) {
-      j = out[key];
-      out[key] = (j == null && j !== 0) ? tmp.value : [].concat(j, tmp.value);
+        break;
+      case /(checkbox)/i.test(input.type):
+        if (input.checked) {
+          response[input.name] = [...(response[input.name] || []), input.value];
+        }
+        break;
+      default:
+        if (input.value) {
+          response[input.name] = input.value;
+        }
+        break;
     }
-  }
-  return out;
+  });
+  return response;
 }
 
 export function deserialize(form, values) {
-  let i = 0, tmp;
-  const rgx1 = /(radio|checkbox)/i;
-
-  while (tmp = form.elements[i++]) {
-    if (!tmp.name) continue;
-
-    if (rgx1.test(tmp.type)) {
-      if (!values[tmp.name]) continue
-
-      if (values[tmp.name].includes(tmp.value)) {
-        tmp.checked = true
-      } else {
-        tmp.checked = false;
-      }
-    } else {
-      tmp.value = values[tmp.name] ? values[tmp.name] : ""
+  [...form.elements].forEach(function elements(input, _index) {
+    // I know this "switch (true)" isn't beautiful, but it works!!!
+    switch (true) {
+      case !input.name:
+      case input.disabled:
+      case /(file|reset|submit|button)/i.test(input.type):
+        break;
+      case /(select-multiple)/i.test(input.type):
+        [...input.options].forEach(function options(option, _selectIndex) {
+          option.selected =
+            values[input.name] && values[input.name].includes(option.value);
+        });
+        break;
+      case /(radio)/i.test(input.type):
+        input.checked =
+          values[input.name] && values[input.name] === input.value;
+        break;
+      case /(checkbox)/i.test(input.type):
+        input.checked =
+          values[input.name] && values[input.name].includes(input.value);
+        break;
+      default:
+        input.value = values[input.name] || "";
+        break;
     }
-
-
-  }
-}
-
-
-export function newDeserialize(form, values) {
-  const inputs = Array.from(form.elements).filter(input => input.tagName === "INPUT")
-  console.log('Node: ', inputs)
-  for (let [key, value] of Object.entries(values)) {
-
-  }
+  });
 }


### PR DESCRIPTION
Hi Kevin, saw your presentation at Svelte Society Day 2020 and gave a try to svelte-forms. Unfortunately there was a problem with the multiple-select input that cleared the selection after the second selection. The problem was that deserialize was not handling that type of input.

Unfortunately again, I don't handle code with short variable names very well,  so I refactored all you serialization code (hopefully for the best).

Thank you for this one, it's a very clever and simple solution!