### PR TITLE
Add on:submit event forward

### DIFF
--- a/src/Form.svelte
+++ b/src/Form.svelte
@@ -9,6 +9,7 @@
 <form
   on:update={({ detail }) => (values = detail)}
   use:getValues={values}
-  use:useActions={actions}>
+  use:useActions={actions}
+  on:submit>
   <slot />
 </form>


### PR DESCRIPTION
When a form is submitting (hit enter or click on input[submit]), nothing happens.
It's because the event on:submit is not forwarded.

Based on : https://svelte.dev/tutorial/dom-event-forwarding