### PR TITLE
Change querySelectorAll to a more specific query

### DIFF
--- a/src/actions/form/getValues.js
+++ b/src/actions/form/getValues.js
@@ -3,7 +3,7 @@ import { serialize, deserialize } from '../../utils/serialize'
 export function getValues(node) {
   let initialUpdateDone = 0
 
-  const inputs = [].slice.call(node.querySelectorAll('input'))
+  const inputs = [...node.getElementsByTagName('input')]
 
   inputs.forEach(el => {
     el.oninput = node.onchange


### PR DESCRIPTION
Not sure in this simple case, but generally, `getElementsByTagName` is faster than `querySelectorAll`:

https://humanwhocodes.com/blog/2010/09/28/why-is-getelementsbytagname-faster-that-queryselectorall/